### PR TITLE
Duplicate keys flag, memory leak fixes in tests. Addresses #10

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -137,6 +137,20 @@ INIData_t *ini_read_file_pointer(FILE *file, INIData_t *data, INIError_t *error,
                 return NULL;
             }
 
+            for (size_t i = 0; i < current_section->pair_count; i++)
+                if (strcmp(current_section->pairs[i].key, pair.key) == 0)
+                {
+                    if (flags & INI_DUPLICATE_KEYS_OVERWRITE)
+                        current_section->pairs[i] = pair;
+                    else if (flags & INI_CONTINUE_PAST_ERROR)
+                        continue;
+                    else
+                    {
+                        set_parse_error_(error, line, 0, "Duplicate key in section.");
+                        return NULL;
+                    }
+                }
+
             if (!ini_add_pair_to_section(current_section, pair))
             {
                 if (flags & INI_CONTINUE_PAST_ERROR) continue;
@@ -269,10 +283,6 @@ INIPair_t *ini_add_pair(const INIData_t *data, const char *section, const INIPai
 INIPair_t *ini_add_pair_to_section(INISection_t *section, const INIPair_t pair)
 {
     if (!section) return NULL;
-
-    for (size_t i = 0; i < section->pair_count; i++)
-        if (strcmp(section->pairs[i].key, pair.key) == 0)
-            section->pairs[i] = pair;
 
     if (section->pair_count >= section->pair_allocation)
     {

--- a/ini.c
+++ b/ini.c
@@ -213,7 +213,10 @@ INIData_t *ini_read_file_pointer(FILE *file, INIData_t *data, INIError_t *error,
     return data;
 }
 
-void ini_write_file_path(const char *path, const INIData_t *data){
+
+
+void ini_write_file_path(const char *path, const INIData_t *data)
+{
     if (!path || !data) return;
     
     FILE *file = fopen(path,"w");
@@ -221,6 +224,8 @@ void ini_write_file_path(const char *path, const INIData_t *data){
     ini_write_file_pointer(file, data);
     fclose(file);
 }
+
+
 
 void ini_write_file_pointer(FILE *file, const INIData_t *data)
 {

--- a/ini.h
+++ b/ini.h
@@ -61,7 +61,7 @@ void               ini_set_reallocator     (void*(*)(void*,    size_t));
 INIData_t         *ini_read_file_path      (const char*,       INIData_t*,       INIError_t*, uint64_t);
 INIData_t         *ini_read_file_pointer   (FILE*,             INIData_t*,       INIError_t*, uint64_t);
 void               ini_write_file_path     (const char*,       const INIData_t*);
-void               ini_write_file_pointer  (FILE*, const INIData_t*);
+void               ini_write_file_pointer  (FILE*,             const INIData_t*);
 
 // Database insertion
 INISection_t      *ini_add_section         (INIData_t*,        const char*);
@@ -152,6 +152,7 @@ void               ini_init_data           (INIData_t*,        INISection_t*,   
 
 #define INI_CONTINUE_PAST_ERROR      (1ull << 0)
 #define INI_ALLOW_DUPLICATE_SECTIONS (1ull << 1)
+#define INI_DUPLICATE_KEYS_OVERWRITE (1ull << 2)
 
 
 

--- a/tests/fuzzing.c
+++ b/tests/fuzzing.c
@@ -48,6 +48,7 @@ TEST(fuzzing, add_section_long_name)
     const INISection_t *sp = ini_add_section(data, section);
     ASSERT_TRUE(sp != NULL);
     ASSERT_EQ(strlen(sp->name), INI_MAX_STRING_SIZE-1);
+    ini_free_data(data);
 }
 
 

--- a/tests/queries.c
+++ b/tests/queries.c
@@ -15,6 +15,7 @@ TEST(queries, add_section)
     const INISection_t *section = ini_add_section(data, "section");
     ASSERT_TRUE(section != NULL);
     ASSERT_TRUE(section == ini_has_section(data, "section"));
+    ini_free_data(data);
 }
 
 


### PR DESCRIPTION
Added a check in the parsing function for duplicate keys. If detected, either errors, ignores the duplicate, or overwrites the old associated value. The behavior is controlled with the existing `INI_CONTINUE_PAST_ERROR` flag and the newly added `INI_DUPLICATE_KEYS_OVERWRITE` flag. Tests were added for this new behavior, and a few memory leaks in existing tests were fixed.